### PR TITLE
bare bones cdn bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,29 @@
-title: Amy Guo
-<h1>Amy Guo</h1>
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+
+    <title>Amy Guo</title>
+  </head>
+  <body>
+    <h1>Amy Guo</h1>
+    <h2>About Me</h2>
+    <i>Guo, 17, is a junior at Sunset High School where she sings in the Chamber Choir and in Madrigals, an advanced ensemble, under the direction of Christopher Rust. She studied piano for 10 years and attained a level 9 in piano syllabus with Oregon Music Teachers Association. Amy has studied voice with Vanessa for 3 years, and prior to that took voice lessons for one year with Alyssa Gibson. <br>A competitive vocal soloist at the National Association of Teachers of Singing Cascade Chapter Classical and Musical Theater festivals, she was a Finalist and Regional Qualifier for the 2018 NATS National Student Auditions competition in the Musical Theatre category. A frequent vocal soloist at the Oregon Music Educators District 15 Middle and High School Solo/Ensemble Competitions, she is also active in Oregon Music Teachers Association activities and was named First Place Winner of the 2019 OMTA Oregon State Senior Voice Scholarship. <br>Amy began acting at Cedar Park Middle School where she portrayed Hodel in Fiddler on the Roof. At Sunset High she played Randall in It’s A Wonderful Life, she was in the Ensembles of Urinetown, The Music Man, and Much Ado About Nothing, and most recently traveled with her choir to New York City’s Carnegie Hall to sing in the “Who Are The Brave?” Concert under the direction of internationally renowned composer, arranger, and conductor Mack Wilberg. <br>While in New York City she was also a featured vocal solo participant in a musical theatre workshop by established Broadway actor and CAP21/Molloy College instructor David Hibbard. <br>Miss Guo intends to continue her vocal studies through college, where she plans to major in Biology and Vocal Arts.</i>
+    <h2>My Singing</h2>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/bS9kXQSQiEc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/w7MGKW2y004" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/rvNDBqI9FrE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
-<h2>About Me</h2>
-
-<i>Guo, 17, is a junior at Sunset High School where she sings in the Chamber Choir and in Madrigals, an advanced ensemble, under the direction of Christopher Rust. She studied piano for 10 years and attained a level 9 in piano syllabus with Oregon Music Teachers Association. Amy has studied voice with Vanessa for 3 years, and prior to that took voice lessons for one year with Alyssa Gibson. <br>A competitive vocal soloist at the National Association of Teachers of Singing Cascade Chapter Classical and Musical Theater festivals, she was a Finalist and Regional Qualifier for the 2018 NATS National Student Auditions competition in the Musical Theatre category. A frequent vocal soloist at the Oregon Music Educators District 15 Middle and High School Solo/Ensemble Competitions, she is also active in Oregon Music Teachers Association activities and was named First Place Winner of the 2019 OMTA Oregon State Senior Voice Scholarship. <br>Amy began acting at Cedar Park Middle School where she portrayed Hodel in Fiddler on the Roof. At Sunset High she played Randall in It’s A Wonderful Life, she was in the Ensembles of Urinetown, The Music Man, and Much Ado About Nothing, and most recently traveled with her choir to New York City’s Carnegie Hall to sing in the “Who Are The Brave?” Concert under the direction of internationally renowned composer, arranger, and conductor Mack Wilberg. <br>While in New York City she was also a featured vocal solo participant in a musical theatre workshop by established Broadway actor and CAP21/Molloy College instructor David Hibbard. <br>Miss Guo intends to continue her vocal studies through college, where she plans to major in Biology and Vocal Arts.</i>
-
-<h2>My Singing</h2>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/bS9kXQSQiEc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/w7MGKW2y004" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/rvNDBqI9FrE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+  </body>
+</html>


### PR DESCRIPTION
The most lightweight possible way to import your bootstrap dependency is through their CDN (content distribution network), as I demonstrate here. It's also covered briefly in their [docs](https://getbootstrap.com/docs/4.4/getting-started/download/#bootstrapcdn).

It's also the most inflexible way! You can't change anything they've setup at that version, so if you want to make custom css, you'll want to have bootstrap available locally.